### PR TITLE
Making Sidekiq Deployment label name a frozen string

### DIFF
--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -33,6 +33,7 @@ module Kuby
             labels do
               add :app, context.plugin.selector_app
               add :role, ROLE
+              add :worker_name, context.name
             end
           end
 
@@ -43,6 +44,7 @@ module Kuby
               match_labels do
                 add :app, context.plugin.selector_app
                 add :role, ROLE
+                add :worker_name, context.name
               end
             end
 
@@ -60,6 +62,7 @@ module Kuby
                 labels do
                   add :app, context.plugin.selector_app
                   add :role, ROLE
+                  add :worker_name, context.name
                 end
               end
 

--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -10,6 +10,7 @@ module Kuby
       extend ::KubeDSL::ValueFields
 
       ROLE='worker'
+      worker_name = context.name.to_s.freeze
 
       attr_reader :plugin, :name, :default_replicas
 
@@ -33,7 +34,7 @@ module Kuby
             labels do
               add :app, context.plugin.selector_app
               add :role, ROLE
-              add :worker_name, context.name
+              add :worker_name, worker_name
             end
           end
 
@@ -44,7 +45,7 @@ module Kuby
               match_labels do
                 add :app, context.plugin.selector_app
                 add :role, ROLE
-                add :worker_name, context.name
+                add :worker_name, worker_name
               end
             end
 
@@ -62,7 +63,7 @@ module Kuby
                 labels do
                   add :app, context.plugin.selector_app
                   add :role, ROLE
-                  add :worker_name, context.name
+                  add :worker_name, worker_name
                 end
               end
 

--- a/lib/kuby/sidekiq/version.rb
+++ b/lib/kuby/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Kuby
   module Sidekiq
-    VERSION = '0.5.0'
+    VERSION = '0.6.0'
   end
 end


### PR DESCRIPTION
## Description: 

The new label on the sidekiq manifest needs to be a string. The cog staging testing on previous symbol version of the label failed:
![image](https://github.com/user-attachments/assets/06c850d7-6bd6-404a-9685-f6d8469bca4b)
