### PR TITLE
Use context string on new label and not on frozen string value

### DIFF
--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -10,7 +10,6 @@ module Kuby
       extend ::KubeDSL::ValueFields
 
       ROLE='worker'
-      worker_name = context.name.to_s.freeze
 
       attr_reader :plugin, :name, :default_replicas
 
@@ -34,7 +33,7 @@ module Kuby
             labels do
               add :app, context.plugin.selector_app
               add :role, ROLE
-              add :worker_name, worker_name
+              add :worker_name, context.name.to_s
             end
           end
 
@@ -45,7 +44,7 @@ module Kuby
               match_labels do
                 add :app, context.plugin.selector_app
                 add :role, ROLE
-                add :worker_name, worker_name
+                add :worker_name, context.name.to_s
               end
             end
 
@@ -63,7 +62,7 @@ module Kuby
                 labels do
                   add :app, context.plugin.selector_app
                   add :role, ROLE
-                  add :worker_name, worker_name
+                  add :worker_name, context.name.to_s
                 end
               end
 

--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -33,6 +33,7 @@ module Kuby
             labels do
               add :app, context.plugin.selector_app
               add :role, ROLE
+              add :worker_name, context.name
             end
           end
 
@@ -43,6 +44,7 @@ module Kuby
               match_labels do
                 add :app, context.plugin.selector_app
                 add :role, ROLE
+                add :worker_name, context.name
               end
             end
 
@@ -60,6 +62,7 @@ module Kuby
                 labels do
                   add :app, context.plugin.selector_app
                   add :role, ROLE
+                  add :worker_name, context.name
                 end
               end
 

--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -10,6 +10,7 @@ module Kuby
       extend ::KubeDSL::ValueFields
 
       ROLE='worker'
+      worker_name = context.name.to_s.freeze
 
       attr_reader :plugin, :name, :default_replicas
 
@@ -33,7 +34,7 @@ module Kuby
             labels do
               add :app, context.plugin.selector_app
               add :role, ROLE
-              add :worker_name, context.name
+              add :worker_name, worker_name
             end
           end
 
@@ -44,7 +45,7 @@ module Kuby
               match_labels do
                 add :app, context.plugin.selector_app
                 add :role, ROLE
-                add :worker_name, context.name
+                add :worker_name, worker_name
               end
             end
 
@@ -62,7 +63,7 @@ module Kuby
                 labels do
                   add :app, context.plugin.selector_app
                   add :role, ROLE
-                  add :worker_name, context.name
+                  add :worker_name, worker_name
                 end
               end
 

--- a/lib/kuby/sidekiq/version.rb
+++ b/lib/kuby/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Kuby
   module Sidekiq
-    VERSION = '0.5.0'
+    VERSION = '0.6.0'
   end
 end


### PR DESCRIPTION
We were relying on a frozen string to set the new label on the worker deployment manifest. We should instead rely on the context self set already to supply that value. 